### PR TITLE
Map adapted for Touch Events, Substituted document.addEventListener for React Event and State Management, General Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,16 @@
-[Interactive Maps](https://github.com/luisconceicaodev/Interactive-Maps) is a tool for creating custom maps
+[Interactive Maps](https://interactive-maps.vercel.app/) is a tool for creating custom maps
 
-Decide what data you want your map to show, select the countries that fit the criteria, color code the countries and give your map a descriptive label. Once you're finished you can download the SVG Map as a PNG
-
-TO DO:
-
-- Acessing maps directly through URL should get the current map through the path instead of the store
-- All NextJS links need to have the pointer cursor
+Decide what data you want your map to show, select the countries that fit the criteria, color code the countries and give your map a descriptive label. Once you're finished you can download the SVG Map as a PNG.
 
 - How to run:
   - npm install
-  - npm run dev
+  - npm run next
 
-- How to deploy on Git Pages:
-  - npm run build
-  - npm run deploy
-  
-Version 1.6
+Version 2.1
 
 - You can now access a demo of this tool through:
 
-  - https://luisconceicaodev.github.io/Interactive-Maps/
+  - https://interactive-maps.vercel.app/
 
 - Features include:
 
@@ -33,7 +24,7 @@ Version 1.6
 
 - Upcoming features:
 
-  - Font options
+  - Map Title and Legend Font customization options
   - File export options (scale, file format, etc.)
   - Customizable background color for the map
   - Button that resets the zoom and the position of the map
@@ -42,6 +33,6 @@ Using public API "REST Countries":
 
 - https://restcountries.com/
 
-Using SVG maps from "simplemaps" (maps slightly altered through Inkscape and by changing the SVG code by hand)
+Using SVG maps from "simplemaps" (maps were slightly altered through the use of Inkscape and by changing the SVG code by hand)
 
 - https://simplemaps.com/

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@testing-library/react": "^11.2.7",
         "@testing-library/user-event": "^12.8.3",
         "bootstrap": "^5.1.3",
+        "clsx": "^1.2.1",
         "eslint-config-next": "^12.3.1",
         "next": "^12.2.2",
         "panzoom": "^9.4.3",
@@ -1573,6 +1574,14 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
       "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
@@ -5558,6 +5567,11 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
       "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+    },
+    "clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
     },
     "color-convert": {
       "version": "1.9.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
     "bootstrap": "^5.1.3",
+    "clsx": "^1.2.1",
     "eslint-config-next": "^12.3.1",
     "next": "^12.2.2",
     "panzoom": "^9.4.3",

--- a/src/components/_common/index.js
+++ b/src/components/_common/index.js
@@ -21,4 +21,4 @@ export const exists = (obj) => {
 export const mapContainsID = (countryID) =>
   exists(document.getElementById(countryID));
 
-export const eventContainsID = (event) => exists(event?.path[0]?.id);
+export const eventContainsID = (event) => exists(event.target.id);

--- a/src/components/atoms/Navigation/navigation.js
+++ b/src/components/atoms/Navigation/navigation.js
@@ -4,23 +4,16 @@ import {
   faCircleXmark,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import clsx from "clsx";
 import Link from "next/link";
+import { useState } from "react";
 import { useDispatch } from "react-redux";
 import { updateCurrentMap } from "../../../redux/mapSlice";
 
 const Navigation = () => {
   const dispatch = useDispatch();
-  // TODO instead of manipulating DOM use the store/state
-  const mobileMenuHandler = () => {
-    const mobileNav = document.querySelector(".mobile-nav");
-    if (mobileNav.className === "mobile-nav") {
-      mobileNav.className += " -active";
-      document.body.classList.add("overflow-hidden");
-    } else {
-      mobileNav.className = "mobile-nav";
-      document.body.classList.remove("overflow-hidden");
-    }
-  };
+  const [menuOpen, setMenuOpen] = useState(false);
+
   return (
     <>
       <div className="top_bar">
@@ -94,24 +87,27 @@ const Navigation = () => {
               </p>
             </Link>
           </div>
-          <a href="#" className="nav-bars" onClick={() => mobileMenuHandler()}>
+          <a href="#" className="nav-bars" onClick={() => setMenuOpen(true)}>
             <FontAwesomeIcon icon={faBars} />
           </a>
         </div>
       </div>
-      <div className="mobile-nav">
+      <div className={clsx("mobile-nav", menuOpen && "-active")}>
         <a href="#">
           <FontAwesomeIcon
             className="mobile-nav-close"
             icon={faCircleXmark}
-            onClick={() => mobileMenuHandler()}
+            onClick={() => setMenuOpen(false)}
           />
         </a>
         <div className="mobile-nav-item">
           <Link href="/world">
             <p
               className="nav-link"
-              onClick={() => dispatch(updateCurrentMap("world"))}
+              onClick={() => {
+                dispatch(updateCurrentMap("world"));
+                setMenuOpen(false);
+              }}
             >
               The World
               <FontAwesomeIcon
@@ -125,7 +121,10 @@ const Navigation = () => {
           <Link href="/europe">
             <p
               className="nav-link"
-              onClick={() => dispatch(updateCurrentMap("europe"))}
+              onClick={() => {
+                dispatch(updateCurrentMap("europe"));
+                setMenuOpen(false);
+              }}
             >
               Europe
               <FontAwesomeIcon
@@ -139,7 +138,10 @@ const Navigation = () => {
           <Link href="/north-america">
             <p
               className="nav-link"
-              onClick={() => dispatch(updateCurrentMap("north-america"))}
+              onClick={() => {
+                dispatch(updateCurrentMap("north-america"));
+                setMenuOpen(false);
+              }}
             >
               North America
               <FontAwesomeIcon
@@ -153,7 +155,10 @@ const Navigation = () => {
           <Link href="/south-america">
             <p
               className="nav-link"
-              onClick={() => dispatch(updateCurrentMap("south-america"))}
+              onClick={() => {
+                dispatch(updateCurrentMap("south-america"));
+                setMenuOpen(false);
+              }}
             >
               South America
               <FontAwesomeIcon
@@ -167,7 +172,10 @@ const Navigation = () => {
           <Link href="/africa">
             <p
               className="nav-link"
-              onClick={() => dispatch(updateCurrentMap("africa"))}
+              onClick={() => {
+                dispatch(updateCurrentMap("africa"));
+                setMenuOpen(false);
+              }}
             >
               Africa
               <FontAwesomeIcon
@@ -181,7 +189,10 @@ const Navigation = () => {
           <Link href="/asia">
             <p
               className="nav-link"
-              onClick={() => dispatch(updateCurrentMap("asia"))}
+              onClick={() => {
+                dispatch(updateCurrentMap("asia"));
+                setMenuOpen(false);
+              }}
             >
               Asia
               <FontAwesomeIcon

--- a/src/components/atoms/Navigation/styles/navigation.styles.scss
+++ b/src/components/atoms/Navigation/styles/navigation.styles.scss
@@ -15,7 +15,6 @@
 
   .logo {
     width: fit-content;
-    height: 100%;
     display: flex;
     justify-content: flex-start;
     margin-left: 1%;
@@ -145,7 +144,6 @@
 
 @media screen and (max-width: 992px) {
   .top_bar {
-    position: unset;
     &.responsive {
       .nav-item {
         float: none;

--- a/src/components/molecules/ColorPicker/colorPicker.js
+++ b/src/components/molecules/ColorPicker/colorPicker.js
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { CirclePicker, SketchPicker } from "react-color";
 import { useDispatch } from "react-redux";
 import { updateColor } from "../../../redux/mapSlice";
-import { CirclePicker, SketchPicker } from "react-color";
 
 const ColorPicker = () => {
   const dispatch = useDispatch();
@@ -21,16 +21,6 @@ const ColorPicker = () => {
       setDisplayPicker(false);
     }
   };
-
-  useEffect(() => {
-    if (displayPicker === true) {
-      document.addEventListener("click", (e) => {
-        if (e.target.contains(document.querySelector(".sketch-picker"))) {
-          setDisplayPicker(false);
-        }
-      });
-    }
-  }, [displayPicker]);
 
   return (
     <>

--- a/src/components/molecules/ColorPicker/styles/colorPicker.styles.scss
+++ b/src/components/molecules/ColorPicker/styles/colorPicker.styles.scss
@@ -15,11 +15,7 @@
 }
 
 .sketch-picker {
-  position: absolute;
+  position: sticky;
   z-index: 2;
   margin: 0;
-  top: 55%;
-  left: 50%;
-  -ms-transform: translate(-50%, -50%);
-  transform: translate(-50%, -50%);
 }

--- a/src/components/molecules/CountryProfile/countryProfile.js
+++ b/src/components/molecules/CountryProfile/countryProfile.js
@@ -87,13 +87,10 @@ const CountryProfile = (currentCountry) => {
               <b>Geographic Region</b>
             </li>
             <li>
-              You can remove the color that has been assigned to a country by
-              right clicking on the country
+              Right click or do a long press on mobile to remove an assigned
+              color
             </li>
-            <li>
-              You can zoom with the mouse wheel and drag the map to change it's
-              position
-            </li>
+            <li>Zoom and drag the map to change it's position</li>
             <li>
               Once you're done color coding, you can fill in the{" "}
               <b>Map Title</b> and <b>Color Legend</b>

--- a/src/components/molecules/GroupSelectors/groupSelectors.js
+++ b/src/components/molecules/GroupSelectors/groupSelectors.js
@@ -1,3 +1,5 @@
+import clsx from "clsx";
+import { useState } from "react";
 import {
   geographicGroupings,
   politicalGroupings,
@@ -5,12 +7,19 @@ import {
 import { groupPicker } from "./utils";
 
 const GroupSelectors = ({ currentMap, dispatch }) => {
+  const [accordionOneOpen, setAccordionOneOpen] = useState(false);
+  const [accordionTwoOpen, setAccordionTwoOpen] = useState(false);
+
   return (
     <div className="accordion" id="groups-accordion">
       <div className="accordion-item">
         <h2 className="accordion-header" id="headingOne">
           <button
-            className="accordion-button collapsed"
+            className={clsx(
+              "accordion-button",
+              accordionOneOpen ? "show" : "collapsed"
+            )}
+            onClick={() => setAccordionOneOpen(!accordionOneOpen)}
             type="button"
             data-bs-toggle="collapse"
             data-bs-target="#collapseOne"
@@ -22,7 +31,10 @@ const GroupSelectors = ({ currentMap, dispatch }) => {
         </h2>
         <div
           id="collapseOne"
-          className="accordion-collapse collapse"
+          className={clsx(
+            "accordion-collapse collapse",
+            accordionOneOpen && "show"
+          )}
           aria-labelledby="headingOne"
           data-bs-parent="#accordionExample"
         >
@@ -46,7 +58,11 @@ const GroupSelectors = ({ currentMap, dispatch }) => {
       <div className="accordion-item">
         <h2 className="accordion-header" id="headingTwo">
           <button
-            className="accordion-button collapsed"
+            className={clsx(
+              "accordion-button",
+              accordionTwoOpen ? "show" : "collapsed"
+            )}
+            onClick={() => setAccordionTwoOpen(!accordionTwoOpen)}
             type="button"
             data-bs-toggle="collapse"
             data-bs-target="#collapseTwo"
@@ -58,7 +74,10 @@ const GroupSelectors = ({ currentMap, dispatch }) => {
         </h2>
         <div
           id="collapseTwo"
-          className="accordion-collapse collapse"
+          className={clsx(
+            "accordion-collapse collapse",
+            accordionTwoOpen && "show"
+          )}
           aria-labelledby="headingTwo"
           data-bs-parent="#accordionExample"
         >

--- a/src/components/organisms/ControlPanel/controlPanel.js
+++ b/src/components/organisms/ControlPanel/controlPanel.js
@@ -1,34 +1,15 @@
 import { useDispatch, useSelector } from "react-redux";
 import { saveSvgAsPng } from "save-svg-as-png";
 import { mapStore } from "../../../redux/mapSlice";
-import ColorPicker from "../../molecules/ColorPicker/colorPicker";
-import { clearAll, selectAll, titleSetter } from "./utils";
-
-import { useEffect } from "react";
 import ColorLegend from "../../molecules/ColorLegend/colorLegend";
+import ColorPicker from "../../molecules/ColorPicker/colorPicker";
 import GroupSelectors from "../../molecules/GroupSelectors/groupSelectors";
+import { clearAll, selectAll, titleSetter } from "./utils";
 
 const ControlPanel = () => {
   const mapState = useSelector(mapStore);
   const dispatch = useDispatch();
   const { currentColor, currentMap } = mapState;
-
-  useEffect(() => {
-    document
-      .getElementById("groups-accordion")
-      .addEventListener("click", (e) => {
-        const toOpen = e.target.dataset.bsTarget;
-        if (e.target.className.includes("accordion-button")) {
-          if (e.target.className.includes("collapsed")) {
-            e.target.classList.remove("collapsed");
-            document.querySelector(toOpen).classList.add("show");
-          } else {
-            e.target.classList.add("collapsed");
-            document.querySelector(toOpen).classList.remove("show");
-          }
-        }
-      });
-  }, []);
 
   return (
     <div className="col-12 mt-4 col-lg-4 mt-lg-0">

--- a/src/components/organisms/Hero/styles/hero.styles.scss
+++ b/src/components/organisms/Hero/styles/hero.styles.scss
@@ -44,6 +44,14 @@
     }
   }
 
+  @media screen and (max-width: 768px) {
+    .earth {
+      width: 200px;
+      height: 200px;
+      background-size: 420px;
+    }
+  }
+
   @keyframes jump {
     0% {
       transform: translateY(5px);
@@ -56,14 +64,27 @@
     }
   }
 
-  @keyframes rotate {
-    0% {
-      background-position: 0 0;
-    }
-    100% {
-      background-position: 630px 0;
+  @media screen and (max-width: 768px) {
+    @keyframes rotate {
+      0% {
+        background-position: 0 0;
+      }
+      100% {
+        background-position: 420px 0;
+      }
     }
   }
+  @media screen and (min-width: 769px) {
+    @keyframes rotate {
+      0% {
+        background-position: 0 0;
+      }
+      100% {
+        background-position: 630px 0;
+      }
+    }
+  }
+
   @keyframes cloudOne {
     0% {
       opacity: 0;
@@ -151,16 +172,6 @@
 }
 
 @media screen and (max-width: 992px) {
-  .earth-container,
-  .text-container {
-    transform: unset;
-    position: unset;
-    #earth {
-      width: 250px;
-      height: 250px;
-    }
-  }
-
   .text-container {
     padding: 35px;
   }

--- a/src/components/organisms/Panel/panel.js
+++ b/src/components/organisms/Panel/panel.js
@@ -23,11 +23,11 @@ const Panel = () => {
             </li>
             <li>
               You can remove the color that has been assigned to a country by
-              right clicking on the country;
+              right clicking on the country or by doing a long press on mobile;
             </li>
             <li>
-              You can zoom with the mouse wheel and drag the map to change it's
-              position;
+              You can zoom through the use of a mouse wheel or through gestures
+              and you can drag the map to change it's position;
             </li>
             <li>
               Once you're done color coding, you can fill in the{" "}

--- a/src/components/organisms/SVGMap/AfricaSVG.js
+++ b/src/components/organisms/SVGMap/AfricaSVG.js
@@ -1,21 +1,68 @@
+import panzoom from "panzoom";
+import { createRef, useEffect, useRef, useState } from "react";
 import MapLegend from "../../atoms/MapLegend/mapLegend";
+import useClick from "./hooks/useClick";
+import useContextMenu from "./hooks/useContextMenu";
+import useMouseOver from "./hooks/useMouseOver";
+import useTouchEnd from "./hooks/useTouchEnd";
 
-const AfricaSVG = () => {
+const AfricaSVG = ({
+  currentMap,
+  store,
+  dispatch,
+  updateUsedColors,
+  removeCountryFromUsedColors,
+}) => {
+  const [action, setAction] = useState("");
+  const timerRef = useRef;
+  const mapRef = createRef();
+  useEffect(() => {
+    panzoom(mapRef.current, {
+      onTouch: function () {
+        return false; // tells the library to not preventDefault.
+      },
+    });
+  }, []);
+
   return (
     <svg
       id="africa"
       baseProfile="tiny"
       className="interactive-map"
-      /* fill="#rgb(45, 190, 47)" */
       fill="#ececec"
-      /* height="584" */ stroke="black"
+      stroke="black"
       strokeLinecap="round"
       strokeLinejoin="round"
       strokeWidth=".2"
       version="1.2"
       viewBox="0 0 1000 684"
-      /* viewBox="-500 -50 2000 1100" */
-      /* width="700" */ xmlns="http://www.w3.org/2000/svg"
+      xmlns="http://www.w3.org/2000/svg"
+      onClick={(event) =>
+        useClick(event, currentMap, store, dispatch, updateUsedColors)
+      }
+      onContextMenu={(event) =>
+        useContextMenu(event, store, dispatch, removeCountryFromUsedColors)
+      }
+      onMouseOver={(event) => useMouseOver(event, currentMap)}
+      onTouchStart={() => {
+        setAction("touch");
+        timerRef.current = setTimeout(() => {
+          setAction("longpress");
+        }, 500);
+      }}
+      onTouchEnd={(event) => {
+        clearTimeout(timerRef.current);
+        useTouchEnd(
+          action,
+          event,
+          currentMap,
+          store,
+          dispatch,
+          updateUsedColors,
+          removeCountryFromUsedColors
+        );
+      }}
+      ref={mapRef}
     >
       {<MapLegend />}
       <path

--- a/src/components/organisms/SVGMap/AsiaSVG.js
+++ b/src/components/organisms/SVGMap/AsiaSVG.js
@@ -1,20 +1,68 @@
+import panzoom from "panzoom";
+import { createRef, useEffect, useRef, useState } from "react";
 import MapLegend from "../../atoms/MapLegend/mapLegend";
+import useClick from "./hooks/useClick";
+import useContextMenu from "./hooks/useContextMenu";
+import useMouseOver from "./hooks/useMouseOver";
+import useTouchEnd from "./hooks/useTouchEnd";
 
-const AsiaSVG = () => {
+const AsiaSVG = ({
+  currentMap,
+  store,
+  dispatch,
+  updateUsedColors,
+  removeCountryFromUsedColors,
+}) => {
+  const [action, setAction] = useState("");
+  const timerRef = useRef;
+  const mapRef = createRef();
+  useEffect(() => {
+    panzoom(mapRef.current, {
+      onTouch: function () {
+        return false; // tells the library to not preventDefault.
+      },
+    });
+  }, []);
+
   return (
     <svg
       id="asia"
       className="interactive-map"
       baseProfile="tiny"
-      /* fill="#rgb(45, 190, 47)" */
       fill="#ececec"
-      /* height="584" */ stroke="black"
+      stroke="black"
       strokeLinecap="round"
       strokeLinejoin="round"
       strokeWidth=".2"
       version="1.2"
       viewBox="0 0 1000 684"
-      /* width="700" */ xmlns="http://www.w3.org/2000/svg"
+      xmlns="http://www.w3.org/2000/svg"
+      onClick={(event) =>
+        useClick(event, currentMap, store, dispatch, updateUsedColors)
+      }
+      onContextMenu={(event) =>
+        useContextMenu(event, store, dispatch, removeCountryFromUsedColors)
+      }
+      onMouseOver={(event) => useMouseOver(event, currentMap)}
+      onTouchStart={() => {
+        setAction("touch");
+        timerRef.current = setTimeout(() => {
+          setAction("longpress");
+        }, 500);
+      }}
+      onTouchEnd={(event) => {
+        clearTimeout(timerRef.current);
+        useTouchEnd(
+          action,
+          event,
+          currentMap,
+          store,
+          dispatch,
+          updateUsedColors,
+          removeCountryFromUsedColors
+        );
+      }}
+      ref={mapRef}
     >
       {<MapLegend />}
       <path

--- a/src/components/organisms/SVGMap/EuropeSVG.js
+++ b/src/components/organisms/SVGMap/EuropeSVG.js
@@ -1,20 +1,68 @@
+import panzoom from "panzoom";
+import { createRef, useEffect, useRef, useState } from "react";
 import MapLegend from "../../atoms/MapLegend/mapLegend";
+import useClick from "./hooks/useClick";
+import useContextMenu from "./hooks/useContextMenu";
+import useMouseOver from "./hooks/useMouseOver";
+import useTouchEnd from "./hooks/useTouchEnd";
 
-const EuropeSVG = () => {
+const EuropeSVG = ({
+  currentMap,
+  store,
+  dispatch,
+  updateUsedColors,
+  removeCountryFromUsedColors,
+}) => {
+  const [action, setAction] = useState("");
+  const timerRef = useRef;
+  const mapRef = createRef();
+  useEffect(() => {
+    panzoom(mapRef.current, {
+      onTouch: function () {
+        return false; // tells the library to not preventDefault.
+      },
+    });
+  }, []);
+
   return (
     <svg
       id="europe"
       className="interactive-map"
       baseProfile="tiny"
-      /* fill="#rgb(45, 190, 47)" */
       fill="#ececec"
-      /* height="584" */ stroke="black"
+      stroke="black"
       strokeLinecap="round"
       strokeLinejoin="round"
       strokeWidth=".2"
       version="1.2"
       viewBox="0 0 1000 684"
-      /* width="700" */ xmlns="http://www.w3.org/2000/svg"
+      xmlns="http://www.w3.org/2000/svg"
+      onClick={(event) =>
+        useClick(event, currentMap, store, dispatch, updateUsedColors)
+      }
+      onContextMenu={(event) =>
+        useContextMenu(event, store, dispatch, removeCountryFromUsedColors)
+      }
+      onMouseOver={(event) => useMouseOver(event, currentMap)}
+      onTouchStart={() => {
+        setAction("touch");
+        timerRef.current = setTimeout(() => {
+          setAction("longpress");
+        }, 500);
+      }}
+      onTouchEnd={(event) => {
+        clearTimeout(timerRef.current);
+        useTouchEnd(
+          action,
+          event,
+          currentMap,
+          store,
+          dispatch,
+          updateUsedColors,
+          removeCountryFromUsedColors
+        );
+      }}
+      ref={mapRef}
     >
       {<MapLegend />}
       <path

--- a/src/components/organisms/SVGMap/NorthAmericaSVG.js
+++ b/src/components/organisms/SVGMap/NorthAmericaSVG.js
@@ -1,6 +1,29 @@
+import panzoom from "panzoom";
+import { createRef, useEffect, useRef, useState } from "react";
 import MapLegend from "../../atoms/MapLegend/mapLegend";
+import useClick from "./hooks/useClick";
+import useContextMenu from "./hooks/useContextMenu";
+import useMouseOver from "./hooks/useMouseOver";
+import useTouchEnd from "./hooks/useTouchEnd";
 
-const NorthAmericaSVG = () => {
+const NorthAmericaSVG = ({
+  currentMap,
+  store,
+  dispatch,
+  updateUsedColors,
+  removeCountryFromUsedColors,
+}) => {
+  const [action, setAction] = useState("");
+  const timerRef = useRef;
+  const mapRef = createRef();
+  useEffect(() => {
+    panzoom(mapRef.current, {
+      onTouch: function () {
+        return false; // tells the library to not preventDefault.
+      },
+    });
+  }, []);
+
   return (
     <svg
       id="north-america"
@@ -14,6 +37,32 @@ const NorthAmericaSVG = () => {
       version="1.2"
       viewBox="0 0 1000 684"
       xmlns="http://www.w3.org/2000/svg"
+      onClick={(event) =>
+        useClick(event, currentMap, store, dispatch, updateUsedColors)
+      }
+      onContextMenu={(event) =>
+        useContextMenu(event, store, dispatch, removeCountryFromUsedColors)
+      }
+      onMouseOver={(event) => useMouseOver(event, currentMap)}
+      onTouchStart={() => {
+        setAction("touch");
+        timerRef.current = setTimeout(() => {
+          setAction("longpress");
+        }, 500);
+      }}
+      onTouchEnd={(event) => {
+        clearTimeout(timerRef.current);
+        useTouchEnd(
+          action,
+          event,
+          currentMap,
+          store,
+          dispatch,
+          updateUsedColors,
+          removeCountryFromUsedColors
+        );
+      }}
+      ref={mapRef}
     >
       {<MapLegend />}
       <path

--- a/src/components/organisms/SVGMap/SouthAmericaSVG.js
+++ b/src/components/organisms/SVGMap/SouthAmericaSVG.js
@@ -1,20 +1,68 @@
+import panzoom from "panzoom";
+import { createRef, useEffect, useRef, useState } from "react";
 import MapLegend from "../../atoms/MapLegend/mapLegend";
+import useClick from "./hooks/useClick";
+import useContextMenu from "./hooks/useContextMenu";
+import useMouseOver from "./hooks/useMouseOver";
+import useTouchEnd from "./hooks/useTouchEnd";
 
-const SouthAmericaSVG = () => {
+const SouthAmericaSVG = ({
+  currentMap,
+  store,
+  dispatch,
+  updateUsedColors,
+  removeCountryFromUsedColors,
+}) => {
+  const [action, setAction] = useState("");
+  const timerRef = useRef;
+  const mapRef = createRef();
+  useEffect(() => {
+    panzoom(mapRef.current, {
+      onTouch: function () {
+        return false; // tells the library to not preventDefault.
+      },
+    });
+  }, []);
+
   return (
     <svg
       id="south-america"
       className="interactive-map"
       baseProfile="tiny"
-      /* fill="#rgb(45, 190, 47)" */
       fill="#ececec"
-      /* height="584" */ stroke="black"
+      stroke="black"
       strokeLinecap="round"
       strokeLinejoin="round"
       strokeWidth=".2"
       version="1.2"
       viewBox="0 0 1000 684"
-      /* width="700" */ xmlns="http://www.w3.org/2000/svg"
+      xmlns="http://www.w3.org/2000/svg"
+      onClick={(event) =>
+        useClick(event, currentMap, store, dispatch, updateUsedColors)
+      }
+      onContextMenu={(event) =>
+        useContextMenu(event, store, dispatch, removeCountryFromUsedColors)
+      }
+      onMouseOver={(event) => useMouseOver(event, currentMap)}
+      onTouchStart={() => {
+        setAction("touch");
+        timerRef.current = setTimeout(() => {
+          setAction("longpress");
+        }, 500);
+      }}
+      onTouchEnd={(event) => {
+        clearTimeout(timerRef.current);
+        useTouchEnd(
+          action,
+          event,
+          currentMap,
+          store,
+          dispatch,
+          updateUsedColors,
+          removeCountryFromUsedColors
+        );
+      }}
+      ref={mapRef}
     >
       {<MapLegend />}
       <path

--- a/src/components/organisms/SVGMap/WorldSVG.js
+++ b/src/components/organisms/SVGMap/WorldSVG.js
@@ -1,20 +1,68 @@
+import panzoom from "panzoom";
+import { createRef, useEffect, useRef, useState } from "react";
 import MapLegend from "../../atoms/MapLegend/mapLegend";
+import useClick from "./hooks/useClick";
+import useContextMenu from "./hooks/useContextMenu";
+import useMouseOver from "./hooks/useMouseOver";
+import useTouchEnd from "./hooks/useTouchEnd";
 
-const WorldSVG = () => {
+const WorldSVG = ({
+  currentMap,
+  store,
+  dispatch,
+  updateUsedColors,
+  removeCountryFromUsedColors,
+}) => {
+  const [action, setAction] = useState("");
+  const timerRef = useRef;
+  const mapRef = createRef();
+  useEffect(() => {
+    panzoom(mapRef.current, {
+      onTouch: function () {
+        return false; // tells the library to not preventDefault.
+      },
+    });
+  }, []);
+
   return (
     <svg
       id="world"
       className="interactive-map"
       baseProfile="tiny"
-      /* fill="#rgb(45, 190, 47)" */
       fill="#ececec"
-      /* height="584" */ stroke="black"
+      stroke="black"
       strokeLinecap="round"
       strokeLinejoin="round"
       strokeWidth=".2"
       version="1.2"
       viewBox="0 0 1300 684"
-      /* width="700" */ xmlns="http://www.w3.org/2000/svg"
+      xmlns="http://www.w3.org/2000/svg"
+      onClick={(event) =>
+        useClick(event, currentMap, store, dispatch, updateUsedColors)
+      }
+      onContextMenu={(event) =>
+        useContextMenu(event, store, dispatch, removeCountryFromUsedColors)
+      }
+      onMouseOver={(event) => useMouseOver(event, currentMap)}
+      onTouchStart={() => {
+        setAction("touch");
+        timerRef.current = setTimeout(() => {
+          setAction("longpress");
+        }, 500);
+      }}
+      onTouchEnd={(event) => {
+        clearTimeout(timerRef.current);
+        useTouchEnd(
+          action,
+          event,
+          currentMap,
+          store,
+          dispatch,
+          updateUsedColors,
+          removeCountryFromUsedColors
+        );
+      }}
+      ref={mapRef}
     >
       {<MapLegend />}
       <path

--- a/src/components/organisms/SVGMap/hooks/useClick.js
+++ b/src/components/organisms/SVGMap/hooks/useClick.js
@@ -1,0 +1,27 @@
+import { eventContainsID } from "../../../_common";
+import { ClassClickHandler, IDClickHandler } from "../utils";
+
+/**
+ * useClick is a custom react hook that handles the user click event on the map
+ * If clicked path has an ID, sets the color to the selected country
+ * Otherwise sets the color to all elements with the selected country's class
+ *  */
+const useClick = (event, currentMap, store, dispatch, updateUsedColors) => {
+  eventContainsID(event)
+    ? IDClickHandler(
+        event.target.id,
+        currentMap,
+        store,
+        dispatch,
+        updateUsedColors
+      )
+    : ClassClickHandler(
+        event.target.classList[0],
+        currentMap,
+        store,
+        dispatch,
+        updateUsedColors
+      );
+};
+
+export default useClick;

--- a/src/components/organisms/SVGMap/hooks/useContextMenu.js
+++ b/src/components/organisms/SVGMap/hooks/useContextMenu.js
@@ -1,0 +1,31 @@
+import { eventContainsID } from "../../../_common";
+import { ClassContextHandler, IDContextHandler } from "../utils";
+
+/**
+ * useContextMenu is a custom react hook that handles the user context menu event on the map
+ * If clicked path has an ID, removes the color of the selected country
+ * Otherwise removes the color to all elements with the selected country's class
+ *  */
+const useContextMenu = (
+  event,
+  store,
+  dispatch,
+  removeCountryFromUsedColors
+) => {
+  event.preventDefault();
+  eventContainsID(event)
+    ? IDContextHandler(
+        event.target.id,
+        store,
+        dispatch,
+        removeCountryFromUsedColors
+      )
+    : ClassContextHandler(
+        event.target.classList[0],
+        store,
+        dispatch,
+        removeCountryFromUsedColors
+      );
+};
+
+export default useContextMenu;

--- a/src/components/organisms/SVGMap/hooks/useMouseOver.js
+++ b/src/components/organisms/SVGMap/hooks/useMouseOver.js
@@ -1,0 +1,14 @@
+import { eventContainsID } from "../../../_common";
+import { ClassHoverHandler, IDHoverHandler } from "../utils";
+
+/**
+ * useMouseOver is a custom react hook that handles the user hover event on the map
+ * Handles the highlighting of the country's borders on hover
+ *  */
+const useMouseOver = (event, currentMap) => {
+  eventContainsID(event)
+    ? IDHoverHandler(event.target.id, currentMap)
+    : ClassHoverHandler(event.target.classList, currentMap);
+};
+
+export default useMouseOver;

--- a/src/components/organisms/SVGMap/hooks/useTouchEnd.js
+++ b/src/components/organisms/SVGMap/hooks/useTouchEnd.js
@@ -1,0 +1,23 @@
+import useClick from "./useClick";
+import useContextMenu from "./useContextMenu";
+
+/**
+ * useTouchEnd is a custom react hook that handles the user touch event on the map
+ * * If the user did a long press then the useContextMenu will be triggered and country will be cleared out
+ * * Otherwise the useClick hook will be triggered and the country will be selected
+ *  */
+const useTouchEnd = (
+  action,
+  event,
+  currentMap,
+  store,
+  dispatch,
+  updateUsedColors,
+  removeCountryFromUsedColors
+) => {
+  action === "longpress"
+    ? useContextMenu(event, store, dispatch, removeCountryFromUsedColors)
+    : useClick(event, currentMap, store, dispatch, updateUsedColors);
+};
+
+export default useTouchEnd;

--- a/src/components/organisms/SVGMap/svgMap.js
+++ b/src/components/organisms/SVGMap/svgMap.js
@@ -1,6 +1,4 @@
 import { useRouter } from "next/router";
-import panzoom from "panzoom";
-import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
   mapStore,
@@ -10,20 +8,12 @@ import {
 } from "../../../redux/mapSlice";
 import { store } from "../../../redux/store";
 import CountryProfile from "../../molecules/CountryProfile/countryProfile";
-import { eventContainsID, exists } from "../../_common";
+import { exists } from "../../_common";
 import AfricaSVG from "./AfricaSVG";
 import AsiaSVG from "./AsiaSVG";
 import EuropeSVG from "./EuropeSVG";
 import NorthAmericaSVG from "./NorthAmericaSVG";
 import SouthAmericaSVG from "./SouthAmericaSVG";
-import {
-  ClassClickHandler,
-  ClassContextHandler,
-  ClassHoverHandler,
-  IDClickHandler,
-  IDContextHandler,
-  IDHoverHandler,
-} from "./utils";
 import WorldSVG from "./WorldSVG";
 
 const SVGMap = () => {
@@ -37,69 +27,25 @@ const SVGMap = () => {
     : router.query?.mapPath;
 
   const currentCountry = mapState.currentCountry;
-
-  useEffect(() => {
-    // Handles the right click (paint action)
-    document.getElementById(currentMap)?.addEventListener("click", (event) => {
-      eventContainsID(event)
-        ? IDClickHandler(
-            event.path[0].id,
-            currentMap,
-            store,
-            dispatch,
-            updateUsedColors
-          )
-        : ClassClickHandler(
-            event.path[0].classList[0],
-            currentMap,
-            store,
-            dispatch,
-            updateUsedColors
-          );
-    });
-    // Handles the left click (clean action)
-    document
-      .getElementById(currentMap)
-      ?.addEventListener("contextmenu", (event) => {
-        event.preventDefault();
-        eventContainsID(event)
-          ? IDContextHandler(
-              event.path[0].id,
-              store,
-              dispatch,
-              removeCountryFromUsedColors
-            )
-          : ClassContextHandler(
-              event.path[0].classList[0],
-              store,
-              dispatch,
-              removeCountryFromUsedColors
-            );
-      });
-    // Handles the hover (country borders highlight)
-    document
-      .getElementById(currentMap)
-      ?.addEventListener("mouseover", (event) => {
-        eventContainsID(event)
-          ? IDHoverHandler(event.path[0].id, currentMap)
-          : ClassHoverHandler(event.path[0].classList, currentMap);
-      });
-    // Handles the drag and scroll (map position and axis)
-    var element = document.querySelector(".interactive-map");
-    panzoom(element, { step: 0.05 });
-  }, [currentMap]);
+  const SVGProps = {
+    currentMap,
+    store,
+    dispatch,
+    updateUsedColors,
+    removeCountryFromUsedColors,
+  };
 
   return (
     <div className="col-12 col-lg-8">
       <div className="svg-container overflow-hidden">
-        {currentMap === "africa" && <AfricaSVG />}
-        {currentMap === "asia" && <AsiaSVG />}
-        {currentMap === "europe" && <EuropeSVG />}
-        {currentMap === "north-america" && <NorthAmericaSVG />}
-        {currentMap === "south-america" && <SouthAmericaSVG />}
-        {currentMap === "world" && <WorldSVG />}
+        {currentMap === "africa" && <AfricaSVG {...SVGProps} />}
+        {currentMap === "asia" && <AsiaSVG {...SVGProps} />}
+        {currentMap === "europe" && <EuropeSVG {...SVGProps} />}
+        {currentMap === "north-america" && <NorthAmericaSVG {...SVGProps} />}
+        {currentMap === "south-america" && <SouthAmericaSVG {...SVGProps} />}
+        {currentMap === "world" && <WorldSVG {...SVGProps} />}
       </div>
-      {CountryProfile(currentCountry)}
+      <CountryProfile {...currentCountry} />
     </div>
   );
 };


### PR DESCRIPTION
- Deprecated many document.addEventListeners and querySelectors/getElementById in favor of React Event Handling, State Management and Refs;
- Adapted the Map making tool to handle touch start and touch end events;
- Updated tutorial to include Mobile clear country mechanism;
- Reduced earth size for screens with less than 768px width;
- Fixed the mobile menu not automatically closing when selecting a map;
- Fixed "More Colors" picker position.