### PR TITLE
Improved Drag, Zoom and Long Press for Touchscreens

### DIFF
--- a/src/components/organisms/SVGMap/styles/europeMap.styles.scss
+++ b/src/components/organisms/SVGMap/styles/europeMap.styles.scss
@@ -1,6 +1,14 @@
 .svg-container {
   border-radius: 25px;
   background-color: #102946;
+  /* 
+  On touchscreens the following proprieties avoid 
+  the zooming and dragging gestures to be interpreted 
+  as default browser gestures and avoids the long press
+  from being interpreted as text selection
+  */
+  touch-action: none;
+  user-select: none;
 }
 
 #europe,


### PR DESCRIPTION
Now touchscreens can:
- Drag and Zoom the Map Maker without triggering the browser gestures
- Longpress a country without the action being interpreted as text selection by the browser